### PR TITLE
Delete technician

### DIFF
--- a/src/components/Cards/CardUser.tsx
+++ b/src/components/Cards/CardUser.tsx
@@ -2,6 +2,7 @@ import { Client, role, Technician } from "@/types";
 import { FiEdit3 } from "react-icons/fi";
 import DetailModal from "../detailModal/DetailModal";
 import useClient from "@/hook/useClient/useClient";
+import useTechnician from "@/hook/useTechnician/useTechnician";
 import DeleteButton from "@/components/deleteButton/deleteButton";
 
 type CardProps = {
@@ -12,14 +13,19 @@ type CardProps = {
 
 const Card = ({ item, userType, classname }: CardProps) => {
   const isClient = userType === role.client;
+  const isTechnician = userType === role.technician;
 
-  const { deleteClient } = useClient({
-    clientId: isClient ? (item as Client).id : undefined,
-  });
+  const clientId = isClient ? (item as Client).id : undefined;
+  const technicianId = isTechnician ? (item as Technician).id : undefined;
+
+  const { deleteClient } = useClient({ clientId });
+  const { deleteTechnician } = useTechnician({ technicianId });
 
   const handleDelete = async () => {
     if (isClient) {
       await deleteClient();
+    } else {
+      await deleteTechnician();
     }
   };
 
@@ -39,7 +45,7 @@ const Card = ({ item, userType, classname }: CardProps) => {
           icon={<FiEdit3 className="w-4 h-4" />}
           user={item as Client}
         />
-        {isClient && (
+        {(isClient || isTechnician) && (
           <DeleteButton userName={item.name} onConfirm={handleDelete} />
         )}
       </div>

--- a/src/hook/useTechnician/useTechnician.tsx
+++ b/src/hook/useTechnician/useTechnician.tsx
@@ -1,0 +1,48 @@
+import { BASE_URL } from "@/constants";
+import UserContext from "@/context/userContext";
+import { notifyPositionMap, notifyType } from "@/types";
+import { useContext } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import axios, { AxiosError } from "axios";
+import useNotify from "../useNotify";
+
+type UseTechnicianProps = {
+  technicianId?: number;
+};
+
+const useTechnician = ({ technicianId }: UseTechnicianProps) => {
+  const {
+    user: { token },
+  } = useContext(UserContext);
+
+  const notify = useNotify();
+  const queryClient = useQueryClient();
+  const header = { headers: { Authorization: `Bearer ${token}` } };
+
+  const deleteTechnician = async () => {
+    try {
+      await axios.delete(`${BASE_URL}/technician/${technicianId}`, header);
+      queryClient.invalidateQueries({ queryKey: ["getAllTechnicians"] });
+      queryClient.invalidateQueries({ queryKey: ["getTechnicianBySearch"] });
+
+      notify(
+        "Técnico excluído com sucesso!",
+        notifyPositionMap.topRight,
+        notifyType.success
+      );
+    } catch (error) {
+      const err = error as AxiosError;
+      notify(
+        err.message || "Erro ao excluir técnico.",
+        notifyPositionMap.topRight,
+        notifyType.error
+      );
+    }
+  };
+
+  return {
+    deleteTechnician,
+  };
+};
+
+export default useTechnician;


### PR DESCRIPTION

<img width="1144" height="595" alt="desktop 1" src="https://github.com/user-attachments/assets/76f23522-501d-4e3a-99b9-3015d3467c9a" />
<img width="636" height="578" alt="mobile 1" src="https://github.com/user-attachments/assets/2f6881b8-78aa-4a87-8902-530435d77a27" />
<img width="1355" height="600" alt="desktop 2" src="https://github.com/user-attachments/assets/2ee18a47-7192-439d-8dc9-30c56dd8bd04" />



Este PR implementa a funcionalidade de exclusão de técnicos no sistema. Agora, usuários com permissão podem remover registros de técnicos diretamente pelo componente CardUser.

✅ Alterações realizadas
Adição do hook useTechnician com a função deleteTechnician, responsável por realizar a requisição de exclusão via API e atualizar o cache das queries relacionadas aos técnicos.

Ajuste no componente CardUser para:

Verificar se o item é um técnico ou cliente.

Exibir o botão de exclusão (DeleteButton) para ambos os tipos de usuário (client e technician).

Acionar a função correspondente (deleteClient ou deleteTechnician) conforme o tipo do usuário.

📌 Observações
A exclusão dispara uma notificação de sucesso ou erro, informando o status da operação.

As queries getAllTechnicians e getTechnicianBySearch são invalidadas após a exclusão para manter os dados atualizados.