### PR TITLE
Extract deletePart function from useGetPart to a dedicated

### DIFF
--- a/src/components/Cards/CardPart.tsx
+++ b/src/components/Cards/CardPart.tsx
@@ -1,9 +1,7 @@
-
 import { Part } from "@/types";
 import DeleteButton from "../deleteButton/deleteButton";
 import DetailModalPart from "../detailModal/partModal";
-import usePart from "@/hook/usePart/useGetPart";
-
+import useDeletePart from "@/hook/usePart/useDeletePart"; // novo hook para deletar
 
 type CardPartProp = {
   classname?: string;
@@ -11,10 +9,10 @@ type CardPartProp = {
 };
 
 const CardPart = ({ part, classname }: CardPartProp) => {
-  const { deletePart } = usePart({ partId: part.id });
+  const { deletePart } = useDeletePart();
 
   const handleDelete = async () => {
-    await deletePart();
+    await deletePart(part.id); // agora passamos o id no momento da chamada
   };
 
   return (
@@ -23,16 +21,13 @@ const CardPart = ({ part, classname }: CardPartProp) => {
     >
       <div className="flex flex-1 items-center">
         <p className="text-sm font-medium md:w-1/3 w-1/2">{part?.name}</p>
-        <p className=" text-sm font-medium w-1/3 pl-6 ">{`R$ ${part?.price}`}</p>
+        <p className="text-sm font-medium w-1/3 pl-6">{`R$ ${part?.price}`}</p>
         <p className="text-sm font-medium md:w-1/3 w-1/2 pl-[4.625rem] md:block hidden">
           {part?.quantity}
         </p>
       </div>
       <div className="flex gap-2 h-7 items-center">
-        
-        <div className="flex gap-2 h-7 items-center">
-          <DetailModalPart part={part} />
-        </div>
+        <DetailModalPart part={part} />
         <DeleteButton
           name={part.name}
           typeLabel="da peça"

--- a/src/hook/usePart/useDeletePart.tsx
+++ b/src/hook/usePart/useDeletePart.tsx
@@ -1,0 +1,37 @@
+import { BASE_URL } from "@/constants";
+import UserContext from "@/context/userContext";
+import { notifyPositionMap, notifyType } from "@/types";
+import axios, { AxiosError } from "axios";
+import { useContext } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import useNotify from "../useNotify";
+
+const useDeletePart = () => {
+  const queryClient = useQueryClient();
+  const {
+    user: { token },
+  } = useContext(UserContext);
+
+  const notify = useNotify();
+  const header = { headers: { Authorization: `Bearer ${token}` } };
+
+  const deletePart = async (partId: number) => {
+    try {
+      await axios.delete(`${BASE_URL}/part/${partId}`, header);
+      queryClient.invalidateQueries({ queryKey: ["getAllPart"] });
+      queryClient.invalidateQueries({ queryKey: ["getpartBySearch"] });
+      notify(
+        "Peça excluída com sucesso!",
+        notifyPositionMap.topRight,
+        notifyType.success
+      );
+    } catch (error) {
+      const err = error as AxiosError;
+      notify(err.message, notifyPositionMap.topRight, notifyType.error);
+    }
+  };
+
+  return { deletePart };
+};
+
+export default useDeletePart;

--- a/src/hook/usePart/useGetPart.tsx
+++ b/src/hook/usePart/useGetPart.tsx
@@ -4,7 +4,7 @@ import { notifyPositionMap, notifyType, PageParam, Part } from "@/types";
 import axios, { AxiosError } from "axios";
 import { useContext } from "react";
 import useNotify from "../useNotify";
-import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 type PartPaginatedResponse = {
   parts: Part[];
@@ -12,14 +12,12 @@ type PartPaginatedResponse = {
   page: number;
 };
 
-const usePart = ({ partId }: { partId?: number } = {}) => {
-  const queryClient = useQueryClient();
+const useGetPart = () => {
   const {
     user: { token },
   } = useContext(UserContext);
 
   const notify = useNotify();
-
   const header = { headers: { Authorization: `Bearer ${token}` } };
 
   const getPartById = async (id: string): Promise<Part> => {
@@ -35,26 +33,6 @@ const usePart = ({ partId }: { partId?: number } = {}) => {
     try {
       const response = await axios.get(requestURL, header);
       return response.data;
-    } catch (error) {
-      const err = error as AxiosError;
-      notify(
-        err.message as string,
-        notifyPositionMap.topRight,
-        notifyType.error
-      );
-    }
-  };
-
-  const deletePart = async () => {
-    try {
-      await axios.delete(`${BASE_URL}/part/${partId}`, header);
-      queryClient.invalidateQueries({ queryKey: ["getAllPart"] });
-      queryClient.invalidateQueries({ queryKey: ["getpartBySearch"] });
-      notify(
-        "Peça excluída com sucesso!",
-        notifyPositionMap.topRight,
-        notifyType.success
-      );
     } catch (error) {
       const err = error as AxiosError;
       notify(err.message, notifyPositionMap.topRight, notifyType.error);
@@ -78,16 +56,13 @@ const usePart = ({ partId }: { partId?: number } = {}) => {
   });
 
   const parts = paginatedPart
-    ? paginatedPart?.pages.flatMap((page) => {
-        return page?.parts;
-      })
+    ? paginatedPart.pages.flatMap((page) => page?.parts ?? [])
     : [];
 
   return {
     getPartById,
     getAllPart,
     fetchNextPage,
-    deletePart,
     hasNextPage,
     isLoading,
     isFetchingNextPage,
@@ -95,4 +70,4 @@ const usePart = ({ partId }: { partId?: number } = {}) => {
   };
 };
 
-export default usePart;
+export default useGetPart;


### PR DESCRIPTION
Este PR realiza uma refatoração importante no código relacionado à gestão das peças (Part).

O que foi feito:
A função responsável por deletar uma peça (deletePart) foi extraída do hook useGetPart para um novo hook exclusivo chamado useDeletePart.

Essa mudança visa melhorar a organização do código, separando responsabilidades e facilitando a manutenção futura.

A refatoração também ajuda a reduzir a dívida técnica, tornando o código mais modular e fácil de entender.

O componente que utiliza a função de deletar foi atualizado para consumir o novo hook e passar o id da peça no momento da chamada.

Benefícios:
Código mais limpo e modular.

Facilita testes unitários e reutilização da função de deletar.

Prepara o projeto para futuras melhorias e manutenções com menos riscos de impacto.