### PR TITLE
Prevent rendering CardPart when part is undefined

### DIFF
--- a/src/Pages/listPart.tsx
+++ b/src/Pages/listPart.tsx
@@ -75,6 +75,10 @@ const ListPart = () => {
           {rowVirtualizer.getVirtualItems().map((virtualRow) => {
             const part = displayedParts[virtualRow.index];
 
+            if (!part) {
+              return null;
+            }
+
             return (
               <div
                 key={virtualRow.index}


### PR DESCRIPTION
Foi adicionada uma verificação no componente ListPart para garantir que o CardPart só seja renderizado quando existir um objeto part válido.  Essa alteração previne o erro "Cannot read properties of undefined (reading 'name')" que ocorria durante a renderização da lista virtualizada, quando índices solicitados pelo virtualizador ainda não possuíam dados carregados.
