### PR TITLE
fix: update branch name from 'main' to 'master' in staging deployment

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,7 +2,7 @@ name: Deploy to Staging
 
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
 
 jobs:
   deploy-staging:


### PR DESCRIPTION
fix: update branch name from 'main' to 'master' in staging deployment